### PR TITLE
Color tweaks: highlight branch names in jj status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# Claude Statusline Development Notes
+
+## Quick Commands
+
+### Development
+```bash
+# Run tests
+cargo test
+
+# Build and test locally
+cargo run < sample_input.json
+
+# Install updated binary
+cargo install --path .
+```
+
+### Git/JJ Workflow
+```bash
+# Create feature branch
+jj bookmark create feature-name
+
+# Commit changes
+jj describe -m "feat: description of changes"
+
+# Push and create PR
+jj git push --branch feature-name --allow-new
+gh pr create --title "Title" --body "Description" --head feature-name --base main
+```
+
+## Architecture Notes
+
+### Color Scheme (24-bit RGB)
+- **Directory**: Teal `RGB(64, 224, 208)`
+- **JJ Branch Names**: Bright Hot Pink `RGB(255, 20, 147)` - for prominence  
+- **JJ Commit IDs**: Duller Hot Pink `RGB(200, 80, 140)` - for subtlety
+- **JJ Conflicts**: Duller Hot Pink `RGB(200, 80, 140)`
+- **Model**: Electric Orange `RGB(255, 140, 0)`
+- **Output Style**: Neon Lime `RGB(50, 205, 50)`
+- **Separators**: Dark Grey `RGB(96, 96, 96)`
+
+### File Structure
+- `src/input.rs` - JSON parsing from Claude Code
+- `src/directory.rs` - Path formatting (~ expansion, truncation)
+- `src/jj_status.rs` - JJ repository detection and status parsing
+- `src/output.rs` - Colored terminal output with separate color handling
+- `src/main.rs` - CLI entry point
+
+### Key Design Decisions
+- Uses `jj` command execution instead of `jj-lib` (API stability concerns)
+- Individual color handling for jj components (change ID vs branch names)
+- Test-driven development with 30 comprehensive tests
+- Modular architecture for easy future enhancements
+
+### Testing Strategy
+- Unit tests for each module
+- Integration tests with sample JSON inputs
+- Color code verification in tests
+- Test both with/without jj repositories
+
+## Future Enhancements
+- Consider `jj-lib` migration when API stabilizes
+- Additional repository types (git fallback?)
+- Configurable color themes
+- Performance optimizations for large repositories

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ cargo run < sample_input.json
 2. 🎨 Evolved colors from basic to vibrant 24-bit true colors  
 3. ✨ Added dynamic emojis that change based on repository state
 4. 🧹 Refined to clean layout with elegant section separators
-5. 🚀 All developed through natural conversation and iteration!
+5. 🌟 Enhanced branch highlighting for better visibility
+6. 🚀 All developed through natural conversation and iteration!
 
 ### Implementation Notes
 - Currently uses `jj` commands for repository detection (reliable and simple)
@@ -103,7 +104,11 @@ cargo run < sample_input.json
 
 ### Color Scheme
 - **Directory path**: Vibrant Teal `RGB(64, 224, 208)`
-- **JJ status**: Hot Pink `RGB(255, 20, 147)` 
+- **JJ status**: 
+  - **Branch names**: Bright Hot Pink `RGB(255, 20, 147)` - for prominence
+  - **Commit IDs**: Duller Hot Pink `RGB(200, 80, 140)` - for subtlety
+  - **Conflict indicators**: Duller Hot Pink `RGB(200, 80, 140)` 
+  - **Change asterisk**: White (uncolored)
 - **Model name**: Electric Orange `RGB(255, 140, 0)`
 - **Output style**: Neon Lime `RGB(50, 205, 50)`
 

--- a/sample_input.json
+++ b/sample_input.json
@@ -7,8 +7,8 @@
     "display_name": "Claude 3.5 Sonnet"
   },
   "workspace": {
-    "current_dir": "/Users/gak/src/grabby",
-    "project_dir": "/Users/gak/src/grabby"
+    "current_dir": "/Users/gak/src/claude-statusline",
+    "project_dir": "/Users/gak/src/claude-statusline"
   },
   "version": "1.0.71",
   "output_style": {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     
     // Get jj status
     let jj_info = get_jj_status(&input.workspace.current_dir);
-    let jj_formatted = jj_info.format();
+    let jj_info_option = if jj_info.change_id.is_some() { Some(jj_info) } else { None };
     
     // Determine output style
     let output_style = if input.output_style.name != "default" && input.output_style.name != "null" {
@@ -36,7 +36,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     // Create and format status line
     let status_line = StatusLine {
         directory,
-        jj_info: jj_formatted,
+        jj_info: jj_info_option,
         model_name: input.model.display_name,
         output_style,
     };

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,8 +1,9 @@
 use colored::*;
+use crate::jj_status::JjInfo;
 
 pub struct StatusLine {
     pub directory: String,
-    pub jj_info: Option<String>,
+    pub jj_info: Option<JjInfo>,
     pub model_name: String,
     pub output_style: Option<String>,
 }
@@ -22,15 +23,46 @@ impl StatusLine {
         parts.push(format!("📂 {}", self.directory.truecolor(64, 224, 208)));
 
         // JJ info with dynamic emoji based on changes (no parentheses)
-        // RGB(255, 20, 147) - Deep pink that pops
         if let Some(jj_info) = &self.jj_info {
-            // Check if there are uncommitted changes (indicated by * at the end)
-            let emoji = if jj_info.ends_with('*') {
-                "⚡" // Lightning for uncommitted changes
-            } else {
-                "🔀" // Twisted arrows for clean state
-            };
-            parts.push(format!("{}{} {}", separator, emoji, jj_info.truecolor(255, 20, 147)));
+            if jj_info.change_id.is_some() {
+                // Check if there are uncommitted changes
+                let emoji = if jj_info.has_changes {
+                    "⚡" // Lightning for uncommitted changes
+                } else {
+                    "🔀" // Twisted arrows for clean state
+                };
+                
+                let mut jj_parts = Vec::new();
+                
+                // Add change ID in duller hot pink (greyer)
+                if let Some(change_id) = &jj_info.change_id {
+                    jj_parts.push(change_id.truecolor(200, 80, 140).to_string()); // Duller hot pink with more grey
+                }
+                
+                // Add bookmarks in full hot pink (brightest)
+                if !jj_info.bookmarks.is_empty() {
+                    let bright_bookmarks = jj_info.bookmarks
+                        .iter()
+                        .map(|bookmark| bookmark.truecolor(255, 20, 147).to_string()) // Full hot pink for branch names
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    jj_parts.push(bright_bookmarks);
+                }
+                
+                // Add conflict indicator in duller hot pink (greyer)
+                if jj_info.has_conflict {
+                    jj_parts.push("conflict".truecolor(200, 80, 140).to_string()); // Same as change ID
+                }
+                
+                let mut jj_display = jj_parts.join(" ");
+                
+                // Add asterisk for changes
+                if jj_info.has_changes {
+                    jj_display.push('*');
+                }
+                
+                parts.push(format!("{}{} {}", separator, emoji, jj_display));
+            }
         }
 
         // Model name with brain emoji and space
@@ -75,9 +107,16 @@ mod tests {
 
     #[test]
     fn test_format_with_jj_info() {
+        let jj_info = JjInfo {
+            change_id: Some("abc123".to_string()),
+            bookmarks: vec!["main".to_string()],
+            has_conflict: false,
+            has_changes: true,
+        };
+        
         let status = StatusLine {
             directory: "~/src/grabby".to_string(),
-            jj_info: Some("abc123 main*".to_string()),
+            jj_info: Some(jj_info),
             model_name: "Claude 3.5 Sonnet".to_string(),
             output_style: Some("default".to_string()),
         };
@@ -88,7 +127,9 @@ mod tests {
         assert!(formatted.contains("📂 "));
         assert!(formatted.contains("~/src/grabby"));
         assert!(formatted.contains("⚡ ")); // Should show lightning with space for changes
-        assert!(formatted.contains("abc123 main*"));
+        assert!(formatted.contains("abc123")); // Change ID should be present
+        assert!(formatted.contains("main")); // Bookmark should be present
+        assert!(formatted.contains("*")); // Changes asterisk should be present
         assert!(formatted.contains("🧠 "));
         assert!(formatted.contains("Claude 3.5 Sonnet"));
         assert!(formatted.contains("‧")); // Should contain separator dots
@@ -116,9 +157,16 @@ mod tests {
 
     #[test]
     fn test_format_full_statusline() {
+        let jj_info = JjInfo {
+            change_id: Some("abc123".to_string()),
+            bookmarks: vec!["main".to_string()],
+            has_conflict: true,
+            has_changes: true,
+        };
+        
         let status = StatusLine {
             directory: "~/src/grabby".to_string(),
-            jj_info: Some("abc123 main conflict*".to_string()),
+            jj_info: Some(jj_info),
             model_name: "Claude 3.5 Sonnet".to_string(),
             output_style: Some("Explanatory".to_string()),
         };
@@ -127,7 +175,10 @@ mod tests {
         assert!(formatted.contains("📂 "));
         assert!(formatted.contains("~/src/grabby"));
         assert!(formatted.contains("⚡ ")); // Should show lightning with space for changes
-        assert!(formatted.contains("abc123 main conflict*"));
+        assert!(formatted.contains("abc123")); // Change ID should be present
+        assert!(formatted.contains("main")); // Bookmark should be present
+        assert!(formatted.contains("conflict")); // Conflict indicator should be present
+        assert!(formatted.contains("*")); // Changes asterisk should be present
         assert!(formatted.contains("🧠 "));
         assert!(formatted.contains("Claude 3.5 Sonnet"));
         assert!(formatted.contains("🎭 "));
@@ -138,9 +189,16 @@ mod tests {
 
     #[test]
     fn test_format_with_clean_jj_status() {
+        let jj_info = JjInfo {
+            change_id: Some("abc123".to_string()),
+            bookmarks: vec!["main".to_string()],
+            has_conflict: false,
+            has_changes: false, // No changes = clean
+        };
+        
         let status = StatusLine {
             directory: "~/src/grabby".to_string(),
-            jj_info: Some("abc123 main".to_string()), // No * = clean
+            jj_info: Some(jj_info),
             model_name: "Claude 3.5 Sonnet".to_string(),
             output_style: Some("default".to_string()),
         };
@@ -149,7 +207,9 @@ mod tests {
         assert!(formatted.contains("📂 "));
         assert!(formatted.contains("~/src/grabby"));
         assert!(formatted.contains("🔀 ")); // Should show twisted arrows with space for clean state
-        assert!(formatted.contains("abc123 main"));
+        assert!(formatted.contains("abc123")); // Change ID should be present
+        assert!(formatted.contains("main")); // Bookmark should be present
+        assert!(!formatted.contains("*")); // Should not have changes asterisk
         assert!(formatted.contains("🧠 "));
         assert!(formatted.contains("Claude 3.5 Sonnet"));
         assert!(formatted.contains("‧")); // Should contain separator dots
@@ -167,5 +227,56 @@ mod tests {
         
         let formatted = status.format();
         assert!(!formatted.contains("[null]"));
+    }
+
+    #[test]
+    fn test_brighter_pink_branch_names() {
+        // Test with bookmarks (branch) - branch names should be brighter pink
+        let jj_info_with_branch = JjInfo {
+            change_id: Some("abc123".to_string()),
+            bookmarks: vec!["feature-branch".to_string()],
+            has_conflict: false,
+            has_changes: false,
+        };
+        
+        let status_with_branch = StatusLine {
+            directory: "~/src/grabby".to_string(),
+            jj_info: Some(jj_info_with_branch),
+            model_name: "Claude 3.5 Sonnet".to_string(),
+            output_style: None,
+        };
+        
+        // Test without bookmarks (no branch) - only change ID in regular pink
+        let jj_info_no_branch = JjInfo {
+            change_id: Some("abc123".to_string()),
+            bookmarks: vec![], // No bookmarks = not in named branch
+            has_conflict: false,
+            has_changes: false,
+        };
+        
+        let status_no_branch = StatusLine {
+            directory: "~/src/grabby".to_string(),
+            jj_info: Some(jj_info_no_branch),
+            model_name: "Claude 3.5 Sonnet".to_string(),
+            output_style: None,
+        };
+        
+        let formatted_with_branch = status_with_branch.format();
+        let formatted_no_branch = status_no_branch.format();
+        
+        // Both should contain the change ID
+        assert!(formatted_with_branch.contains("abc123"));
+        assert!(formatted_no_branch.contains("abc123"));
+        
+        // Only the branch version should contain the branch name
+        assert!(formatted_with_branch.contains("feature-branch"));
+        assert!(!formatted_no_branch.contains("feature-branch"));
+        
+        // The formatted output should contain different color codes for branch names
+        // Branch version should have full hot pink for branch names, duller for change ID
+        assert!(formatted_with_branch.contains("255;20;147"));  // Full hot pink for branch name
+        assert!(formatted_with_branch.contains("200;80;140"));   // Duller hot pink for change ID
+        assert!(formatted_no_branch.contains("200;80;140"));     // Only duller hot pink for change ID
+        assert!(!formatted_no_branch.contains("255;20;147"));    // No full hot pink without branches
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -34,12 +34,12 @@ fn test_integration_with_sample_json() {
     
     // Test jj status (will be empty since /Users/gak/src/grabby is not a jj repo in test environment)
     let jj_info = get_jj_status(&input.workspace.current_dir);
-    let jj_formatted = jj_info.format();
+    let jj_info_option = if jj_info.change_id.is_some() { Some(jj_info) } else { None };
     
     // Test output formatting
     let status_line = StatusLine {
         directory,
-        jj_info: jj_formatted,
+        jj_info: jj_info_option,
         model_name: input.model.display_name,
         output_style: None, // default style should be None
     };
@@ -80,7 +80,7 @@ fn test_integration_with_learning_style() {
     assert_eq!(directory, "~/src/claude-statusline");
     
     let jj_info = get_jj_status(&input.workspace.current_dir);
-    let jj_formatted = jj_info.format();
+    let jj_info_option = if jj_info.change_id.is_some() { Some(jj_info) } else { None };
     
     let output_style = if input.output_style.name != "default" && input.output_style.name != "null" {
         Some(input.output_style.name)
@@ -90,7 +90,7 @@ fn test_integration_with_learning_style() {
     
     let status_line = StatusLine {
         directory,
-        jj_info: jj_formatted,
+        jj_info: jj_info_option,
         model_name: input.model.display_name,
         output_style,
     };
@@ -172,7 +172,7 @@ fn test_integration_end_to_end_flow() {
     
     // Get jj status
     let jj_info = get_jj_status(&input.workspace.current_dir);
-    let jj_formatted = jj_info.format();
+    let jj_info_option = if jj_info.change_id.is_some() { Some(jj_info) } else { None };
     
     // Determine output style
     let output_style = if input.output_style.name != "default" && input.output_style.name != "null" {
@@ -184,7 +184,7 @@ fn test_integration_end_to_end_flow() {
     // Create and format status line
     let status_line = StatusLine {
         directory,
-        jj_info: jj_formatted,
+        jj_info: jj_info_option,
         model_name: input.model.display_name,
         output_style,
     };


### PR DESCRIPTION
This PR enhances the statusline with improved color highlighting for better branch visibility.

## Changes

- **Branch names (bookmarks)**: Now use bright hot pink `RGB(255,20,147)` for maximum prominence
- **Commit IDs**: Use duller hot pink `RGB(200,80,140)` with more grey for subtlety
- **Asterisk for changes**: Remains white (unchanged)
- **Conflict indicators**: Use same duller color as commit IDs for consistency

## Visual Impact

**Before**: All jj status components used the same pink color, making it hard to quickly identify the branch
**After**: Branch names pop with bright hot pink while commit IDs are more subdued

This makes it much easier to quickly identify which branch you're working on while keeping other jj status information visible but less prominent.

## Documentation

- Updated README with detailed color scheme breakdown
- Added CLAUDE.md with development notes and color reference
- Enhanced vibe coding journey section

## Testing

- All 30 tests updated and passing  
- New test specifically verifies the color code differences
- Binary tested and installed successfully

🎨 Generated with [Claude Code](https://claude.ai/code)